### PR TITLE
Fix reversePatches indentation in host-only-gateways.yaml

### DIFF
--- a/generic-sync-examples/istio/host-only-gateways.yaml
+++ b/generic-sync-examples/istio/host-only-gateways.yaml
@@ -56,10 +56,10 @@ sync:
             - op: rewriteName
               path: .spec.http[*].route[*].destination.host
               regex: *svcHost
-                reversePatches:
-                  - op: copyFromObject
-                    fromPath: status
-                    path: status
+          reversePatches:
+            - op: copyFromObject
+              fromPath: status
+              path: status
         - apiVersion: networking.istio.io/v1alpha3
           kind: DestinationRule
           patches:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
When trying to apply the example for istio generic-sync-sample, it failed because of a bas indentation of the reversePatches field.
This PR aims to fix this


**Please provide a short message that should be published in the vcluster release notes**
Fixed an issue in the istio generic-sync-example
